### PR TITLE
Retry connection to RabbitMQ on Scheduler Startup

### DIFF
--- a/bin/scheduler.js
+++ b/bin/scheduler.js
@@ -26,6 +26,7 @@ const _loadedJobs = {};
 (async () => {
     try {
         await rabbit.initialize();
+        debug('starting services');
         status.start();
         logwriter.start();
         eventWatcher.start();

--- a/bin/scheduler.js
+++ b/bin/scheduler.js
@@ -9,18 +9,13 @@ const rabbit = require('../lib/rabbitfactory');
 const config = require('../lib/config');
 const constants = require('../lib/constants');
 const Job = require('../models/job');
-// Don't remove.  Loading this causes logger to start
-const logger = require('../lib/logwriter'); // eslint-disable-line no-unused-vars
-// Don't remove.  Loading this causes status to start
-const status = require('../lib/mqstatus'); // eslint-disable-line no-unused-vars
-// Don't remove.  Loading this causes jobwatcher to start
-const jobWatcher = require('../lib/k8s/jobwatcher'); // eslint-disable-line no-unused-vars
-// Don't remove.  Loading this causes eventwatcher to start
-const eventWatcher = require('../lib/k8s/eventwatcher'); // eslint-disable-line no-unused-vars
-// Don't remove.  Loading this causes the zombieRuns to start
-const zombieRuns = require('../lib/k8s/zombieruns'); // eslint-disable-line no-unused-vars
-// Don't remove.  Loading this causes the cleanupJobs to start
-const jobCleanup = require('../lib/k8s/jobcleanup'); // eslint-disable-line no-unused-vars
+
+const logwriter = require('../lib/logwriter');
+const status = require('../lib/mqstatus');
+const jobWatcher = require('../lib/k8s/jobwatcher');
+const eventWatcher = require('../lib/k8s/eventwatcher');
+const zombieRuns = require('../lib/k8s/zombieruns');
+const jobCleanup = require('../lib/k8s/jobcleanup');
 
 const iostatus = require('../lib/iostatus');
 
@@ -30,6 +25,13 @@ const _loadedJobs = {};
 
 (async () => {
     try {
+        await rabbit.initialize();
+        status.start();
+        logwriter.start();
+        eventWatcher.start();
+        jobWatcher.start();
+        zombieRuns.start();
+        jobCleanup.start();
         const jobs = await Job.loadAllJobs();
         debug('loading jobs');
         jobs.forEach((job) => {

--- a/lib/k8s/eventwatcher.js
+++ b/lib/k8s/eventwatcher.js
@@ -36,7 +36,7 @@ async function addToLog(runId, logTime, logMessage) {
     }
 }
 
-const watcher = new Watcher(`/api/v1/namespaces/${constants.NAMESPACE}/events`, async (type, apiObj, watchObj) => {
+module.exports = new Watcher(`/api/v1/namespaces/${constants.NAMESPACE}/events`, async (type, apiObj, watchObj) => {
     // Only interested in pod events
     if (apiObj.involvedObject && apiObj.involvedObject.kind === 'Pod') {
         const podName = apiObj.involvedObject.name;
@@ -74,4 +74,3 @@ const watcher = new Watcher(`/api/v1/namespaces/${constants.NAMESPACE}/events`, 
     }
 });
 
-watcher.start();

--- a/lib/k8s/jobcleanup.js
+++ b/lib/k8s/jobcleanup.js
@@ -12,31 +12,33 @@ const config = require('../config');
 const k8sClient = require('./clientFactory');
 const Job = require('./job');
 
-debug('job cleanup interval: %d minutes', config.scheduler.jobCleanupFrequency);
-setInterval(async function () {
-    debug('looking for jobs to cleanup');
-    // , fieldSelector: 'status.phase!=Running,status.phase!=Pending' } }
-    const jobs = await k8sClient.api.batch.listNamespacedJob(constants.NAMESPACE);
-    debug(`${jobs.body.items.length} jobs found`);
-    // Filter out inactive jobs
-    const filteredJobs = _.filter(jobs.body.items, function (job) {
-        return job.status.active !== 1;
-    });
-    if (filteredJobs.length > 0) {
-        debug(`${filteredJobs.length} active jobs found`);
-        async.eachLimit(filteredJobs, 5, async function (job) {
-            if (job.metadata && job.metadata.labels && job.metadata.labels.runId) {
-                debug(`Removing job for runId: ${job.metadata.labels.runId}`);
-                await Job.remove(job.metadata.labels.runId);
-            }
-        }, function (err) {
-            debug('Finished job cleanup');
-            if (err) {
-                console.error(err);
-            }
+module.exports.start = function start() {
+    debug('job cleanup interval: %d minutes', config.scheduler.jobCleanupFrequency);
+    setInterval(async function () {
+        debug('looking for jobs to cleanup');
+        // , fieldSelector: 'status.phase!=Running,status.phase!=Pending' } }
+        const jobs = await k8sClient.api.batch.listNamespacedJob(constants.NAMESPACE);
+        debug(`${jobs.body.items.length} jobs found`);
+        // Filter out inactive jobs
+        const filteredJobs = _.filter(jobs.body.items, function (job) {
+            return job.status.active !== 1;
         });
-    }
-    else {
-        debug('No jobs found');
-    }
-}, config.scheduler.jobCleanupFrequency * 60000);
+        if (filteredJobs.length > 0) {
+            debug(`${filteredJobs.length} active jobs found`);
+            async.eachLimit(filteredJobs, 5, async function (job) {
+                if (job.metadata && job.metadata.labels && job.metadata.labels.runId) {
+                    debug(`Removing job for runId: ${job.metadata.labels.runId}`);
+                    await Job.remove(job.metadata.labels.runId);
+                }
+            }, function (err) {
+                debug('Finished job cleanup');
+                if (err) {
+                    console.error(err);
+                }
+            });
+        }
+        else {
+            debug('No jobs found');
+        }
+    }, config.scheduler.jobCleanupFrequency * 60000);
+};

--- a/lib/k8s/jobwatcher.js
+++ b/lib/k8s/jobwatcher.js
@@ -25,7 +25,7 @@ async function updateStatus(message) {
     }
 }
 
-const watcher = new Watcher(`/apis/batch/v1/namespaces/${constants.NAMESPACE}/jobs`, async (type, apiObj, watchObj) => {
+module.exports = new Watcher(`/apis/batch/v1/namespaces/${constants.NAMESPACE}/jobs`, async (type, apiObj, watchObj) => {
     if ((type === 'MODIFIED' || type === 'DELETED') && apiObj.status) {
         try {
             if (apiObj.status.completionTime) {
@@ -68,5 +68,3 @@ const watcher = new Watcher(`/apis/batch/v1/namespaces/${constants.NAMESPACE}/jo
         }
     }
 });
-
-watcher.start();

--- a/lib/k8s/zombieruns.js
+++ b/lib/k8s/zombieruns.js
@@ -32,66 +32,68 @@ async function updateStatus(message) {
 // Looks at any run in a idle or busy state with an
 // updatedAt that is more than 5 minutes old and
 // marks it as failed
-debug(`zombie run garbage collection interval: ${config.scheduler.zombieFrequency} minutes`);
-setInterval(async function () {
-    try {
-        debug('garbage collecting zombie runs');
-        const zombieRuns = await Run.find({ $or: [{ status: constants.JOBSTATUS.BUSY }, { status: constants.JOBSTATUS.IDLE }, { status: constants.JOBSTATUS.SCHEDULED }] });
+module.exports.start = function start() {
+    debug(`zombie run garbage collection interval: ${config.scheduler.zombieFrequency} minutes`);
+    setInterval(async function () {
+        try {
+            debug('garbage collecting zombie runs');
+            const zombieRuns = await Run.find({ $or: [{ status: constants.JOBSTATUS.BUSY }, { status: constants.JOBSTATUS.IDLE }, { status: constants.JOBSTATUS.SCHEDULED }] });
 
-        await async.eachLimit(zombieRuns, 5, async function (zombieRun) {
-            const jobs = await k8sClient.api.batch.listNamespacedJob(constants.NAMESPACE, undefined, undefined, undefined, undefined, `runId=${zombieRun._id}`, 1);
-            if (jobs.body.items.length > 0) {
-                const job = jobs.body.items[0];
-                debug('job', job);
-                if (job.status.failed) {
-                    await updateStatus({ status: constants.JOBSTATUS.FAIL, runId: job.metadata.labels.runId, jobId: job.metadata.labels.jobId });
+            await async.eachLimit(zombieRuns, 5, async function (zombieRun) {
+                const jobs = await k8sClient.api.batch.listNamespacedJob(constants.NAMESPACE, undefined, undefined, undefined, undefined, `runId=${zombieRun._id}`, 1);
+                if (jobs.body.items.length > 0) {
+                    const job = jobs.body.items[0];
+                    debug('job', job);
+                    if (job.status.failed) {
+                        await updateStatus({ status: constants.JOBSTATUS.FAIL, runId: job.metadata.labels.runId, jobId: job.metadata.labels.jobId });
+                        zombieRun.status = constants.JOBSTATUS.FAIL;
+                    }
+                    else if (job.status.succeeded) {
+                        await updateStatus({ status: constants.JOBSTATUS.SUCCESS, runId: job.metadata.labels.runId, jobId: job.metadata.labels.jobId });
+                        zombieRun.status = constants.JOBSTATUS.SUCCESS;
+                    }
+                    else if (!job.status.active && moment().subtract(5, 'minutes').isAfter(zombieRun.createdAt)) {
+                        debug(`Job not found updating status to fail runId: ${job.metadata.labels.runId}`);
+                        await updateStatus({ status: constants.JOBSTATUS.FAIL, runId: job.metadata.labels.runId, jobId: job.metadata.labels.jobId });
+                        zombieRun.status = constants.JOBSTATUS.FAIL;
+                    }
+                }
+                else {
+                    debug(`No k8s job found updating status to fail runId: ${zombieRun._id}`);
+                    await updateStatus({ status: constants.JOBSTATUS.FAIL, runId: zombieRun._id, jobId: zombieRun.jobId });
                     zombieRun.status = constants.JOBSTATUS.FAIL;
                 }
-                else if (job.status.succeeded) {
-                    await updateStatus({ status: constants.JOBSTATUS.SUCCESS, runId: job.metadata.labels.runId, jobId: job.metadata.labels.jobId });
-                    zombieRun.status = constants.JOBSTATUS.SUCCESS;
-                }
-                else if (!job.status.active && moment().subtract(5, 'minutes').isAfter(zombieRun.createdAt)) {
-                    debug(`Job not found updating status to fail runId: ${job.metadata.labels.runId}`);
-                    await updateStatus({ status: constants.JOBSTATUS.FAIL, runId: job.metadata.labels.runId, jobId: job.metadata.labels.jobId });
-                    zombieRun.status = constants.JOBSTATUS.FAIL;
-                }
-            }
-            else {
-                debug(`No k8s job found updating status to fail runId: ${zombieRun._id}`);
-                await updateStatus({ status: constants.JOBSTATUS.FAIL, runId: zombieRun._id, jobId: zombieRun.jobId });
-                zombieRun.status = constants.JOBSTATUS.FAIL;
-            }
 
-            await async.parallel([
-                async function () {
-                    try {
-                        return await zombieRun.save();
-                    }
-                    catch (err) {
-                        console.error('Error saving zombieRun', err);
-                    }
-                },
-                async function () {
-                    try {
-                        const job = await Job.findByJobId(zombieRun.jobId);
-                        if (!job) {
-                            console.error('Unable to find jobId: ' + zombieRun.jobId);
+                await async.parallel([
+                    async function () {
+                        try {
+                            return await zombieRun.save();
                         }
-                        else {
-                            job.lastStatus = zombieRun.status;
-                            await job.save();
+                        catch (err) {
+                            console.error('Error saving zombieRun', err);
                         }
-                    }
-                    catch (err) {
-                        console.error('Unable to find jobId: ' + zombieRun.jobId, err);
-                    }
+                    },
+                    async function () {
+                        try {
+                            const job = await Job.findByJobId(zombieRun.jobId);
+                            if (!job) {
+                                console.error('Unable to find jobId: ' + zombieRun.jobId);
+                            }
+                            else {
+                                job.lastStatus = zombieRun.status;
+                                await job.save();
+                            }
+                        }
+                        catch (err) {
+                            console.error('Unable to find jobId: ' + zombieRun.jobId, err);
+                        }
 
-                }
-            ]);
-        });
-    }
-    catch (err) {
-        console.error('ZombieRuns error', err);
-    }
-}, config.scheduler.zombieFrequency * 60000);
+                    }
+                ]);
+            });
+        }
+        catch (err) {
+            console.error('ZombieRuns error', err);
+        }
+    }, config.scheduler.zombieFrequency * 60000);
+};

--- a/lib/logwriter.js
+++ b/lib/logwriter.js
@@ -8,24 +8,26 @@ const iostatus = require('./iostatus');
 
 const debug = require('debug')('tilloo:logwriter');
 
-rabbit.subscribe(constants.QUEUES.LOGGER, async (message) => {
-    debug('logger message', message);
-    if (message && message.runId && message.output) {
-        iostatus.sendLogOutput(message.runId, message.output);
-        try {
-            await Log.append(message.runId, message.output, message.createdAt);
+module.exports.start = function start() {
+    rabbit.subscribe(constants.QUEUES.LOGGER, async (message) => {
+        debug('logger message', message);
+        if (message && message.runId && message.output) {
+            iostatus.sendLogOutput(message.runId, message.output);
+            try {
+                await Log.append(message.runId, message.output, message.createdAt);
 
-            return true;
+                return true;
+            }
+            catch (err) {
+                console.error(err);
+
+                return false;
+            }
         }
-        catch (err) {
-            console.error(err);
+        else {
+            debug('Invalid logger message: ', message);
 
             return false;
         }
-    }
-    else {
-        debug('Invalid logger message: ', message);
-
-        return false;
-    }
-});
+    });
+};

--- a/lib/mqstatus.js
+++ b/lib/mqstatus.js
@@ -12,105 +12,106 @@ const iostatus = require('./iostatus');
 const notifications = require('./notifications.js');
 const debug = require('debug')('tilloo:status');
 
-rabbit.subscribe(constants.QUEUES.STATUS, async (message) => {
-    debug('status message', message);
-    if (message && message.runId && message.status) {
-        // Don't love the write after read pattern but can't find another way to do this with MongoDb
-        // Using the updatedAt to make sure it hasn't changed
-        try {
-            const run = await Run.findById(new ObjectId(message.runId));
-            let update;
-            const date = new Date();
+module.exports.start = function start() {
+    rabbit.subscribe(constants.QUEUES.STATUS, async (message) => {
+        debug('status message', message);
+        if (message && message.runId && message.status) {
+            // Don't love the write after read pattern but can't find another way to do this with MongoDb
+            // Using the updatedAt to make sure it hasn't changed
+            try {
+                const run = await Run.findById(new ObjectId(message.runId));
+                let update;
+                const date = new Date();
 
-            switch (message.status) {
-                case constants.JOBSTATUS.SUCCESS:
-                    // Only allow transition to SUCCESS if in BUSY currently
-                    if (run.status === constants.JOBSTATUS.BUSY || run.status === constants.JOBSTATUS.SCHEDULED || run.status === constants.JOBSTATUS.IDLE) {
-                        update = { completedAt: date, status: constants.JOBSTATUS.SUCCESS };
-                        if (message.result !== undefined) {
-                            update.result = message.result;
+                switch (message.status) {
+                    case constants.JOBSTATUS.SUCCESS:
+                        // Only allow transition to SUCCESS if in BUSY currently
+                        if (run.status === constants.JOBSTATUS.BUSY || run.status === constants.JOBSTATUS.SCHEDULED || run.status === constants.JOBSTATUS.IDLE) {
+                            update = { completedAt: date, status: constants.JOBSTATUS.SUCCESS };
+                            if (message.result !== undefined) {
+                                update.result = message.result;
+                            }
+
+                            notifications.notify(message);
+                        }
+                        else {
+                            debug('not updating status for runId: %s, current status: %s, requested status: %s', message.runId, run.status, message.status);
+                        }
+                        break;
+
+                    case constants.JOBSTATUS.FAIL:
+                        if (run.status === constants.JOBSTATUS.BUSY || run.status === constants.JOBSTATUS.SCHEDULED || run.status === constants.JOBSTATUS.IDLE || message.type === constants.KILLTYPE.MANUAL) {
+                            update = { completedAt: date, status: constants.JOBSTATUS.FAIL };
+                            if (message.result !== undefined && message.result !== null) {
+                                update.result = message.result;
+                            }
+                            if (message.pod) {
+                                update.pod = message.pod;
+                            }
+
+                            notifications.notify(message);
+                        }
+                        else {
+                            debug('not updating status for runId: %s, current status: %s, requested status: %s', message.runId, run.status, message.status);
+                        }
+                        break;
+
+                    case constants.JOBSTATUS.SCHEDULED:
+                        if (run.status === constants.JOBSTATUS.IDLE) {
+                            update = { status: constants.JOBSTATUS.SCHEDULED };
+
+                            notifications.notify(message);
+                        }
+                        else {
+                            debug('not updating status for runId: %s, current status: %s, requested status: %s', message.runId, run.status, message.status);
+                        }
+                        break;
+
+                    case constants.JOBSTATUS.BUSY:
+                        if (run.status === constants.JOBSTATUS.IDLE || run.status === constants.JOBSTATUS.SCHEDULED) {
+                            update = { status: constants.JOBSTATUS.BUSY };
+                            if (message.pod) {
+                                update.pod = message.pod;
+                            }
+                        }
+                        else {
+                            debug('not updating status for runId: %s, current status: %s, requested status: %s', message.runId, run.status, message.status);
                         }
 
-                        notifications.notify(message);
-                    }
-                    else {
-                        debug('not updating status for runId: %s, current status: %s, requested status: %s', message.runId, run.status, message.status);
-                    }
-                    break;
-
-                case constants.JOBSTATUS.FAIL:
-                    if (run.status === constants.JOBSTATUS.BUSY || run.status === constants.JOBSTATUS.SCHEDULED || run.status === constants.JOBSTATUS.IDLE || message.type === constants.KILLTYPE.MANUAL) {
-                        update = { completedAt: date, status: constants.JOBSTATUS.FAIL };
-                        if (message.result !== undefined && message.result !== null) {
-                            update.result = message.result;
-                        }
-                        if (message.pod) {
-                            update.pod = message.pod;
-                        }
-
-                        notifications.notify(message);
-                    }
-                    else {
-                        debug('not updating status for runId: %s, current status: %s, requested status: %s', message.runId, run.status, message.status);
-                    }
-                    break;
-
-                case constants.JOBSTATUS.SCHEDULED:
-                    if (run.status === constants.JOBSTATUS.IDLE) {
-                        update = { status: constants.JOBSTATUS.SCHEDULED };
-
-                        notifications.notify(message);
-                    }
-                    else {
-                        debug('not updating status for runId: %s, current status: %s, requested status: %s', message.runId, run.status, message.status);
-                    }
-                    break;
-
-                case constants.JOBSTATUS.BUSY:
-                    if (run.status === constants.JOBSTATUS.IDLE || run.status === constants.JOBSTATUS.SCHEDULED) {
-                        update = { status: constants.JOBSTATUS.BUSY };
-                        if (message.pod) {
-                            update.pod = message.pod;
-                        }
-                    }
-                    else {
-                        debug('not updating status for runId: %s, current status: %s, requested status: %s', message.runId, run.status, message.status);
-                    }
-
-                    break;
-            }
-
-            if (update) {
-                // Make sure if not shown as started that we update as started as we transition to any of the above
-                // states
-                if (!run.startedAt) {
-                    update.startedAt = new Date();
+                        break;
                 }
 
-                // Make sure we always update updatedAt since middleware won't run
-                update.updatedAt = new Date();
-                debug('Updating status on runId: %s, status: %s', message.runId, message.status, update);
-                // Updated at included to be pessimistic in the update and only update if it hasn't changed
+                if (update) {
+                    // Make sure if not shown as started that we update as started as we transition to any of the above
+                    // states
+                    if (!run.startedAt) {
+                        update.startedAt = new Date();
+                    }
 
-                await Run.findOneAndUpdate({ _id: new ObjectId(message.runId), updatedAt: run.updatedAt }, update, null);
-                iostatus.sendStatus(run.jobId, message.runId, message);
+                    // Make sure we always update updatedAt since middleware won't run
+                    update.updatedAt = new Date();
+                    debug('Updating status on runId: %s, status: %s', message.runId, message.status, update);
+                    // Updated at included to be pessimistic in the update and only update if it hasn't changed
 
-                debug('Updating status on jobId: %s, runId: %s, status: %s', run.jobId, message.runId, message.status);
-                await Job.findByIdAndUpdate(run.jobId, { lastStatus: message.status }, null);
+                    await Run.findOneAndUpdate({ _id: new ObjectId(message.runId), updatedAt: run.updatedAt }, update, null);
+                    iostatus.sendStatus(run.jobId, message.runId, message);
+
+                    debug('Updating status on jobId: %s, runId: %s, status: %s', run.jobId, message.runId, message.status);
+                    await Job.findByIdAndUpdate(run.jobId, { lastStatus: message.status }, null);
+                }
+
+                return true;
             }
+            catch (err) {
+                console.error(err);
 
-            return true;
+                return false;
+            }
         }
-        catch (err) {
-            console.error(err);
+        else {
+            debug('Invalid status message: ', message);
 
             return false;
         }
-    }
-    else {
-        debug('Invalid status message: ', message);
-
-        return false;
-    }
-});
-
+    });
+};

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -52,6 +52,7 @@ async function getInstance() {
                                 ]
                             });
                             debug('rabbitmq connected');
+                            console.dir(rabbot);
                             rabbotInstance = rabbot;
                         }, (err) => {
                             if (err) {
@@ -131,7 +132,7 @@ module.exports.subscribe = async function subscribe(queue, handler) {
 module.exports.publish = async function publish(queue, message) {
     try {
         const r = await getInstance();
-
+        console.dir(r);
         await r.publish(exchange, {
             type: queue,
             routingKey: queue,

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -87,6 +87,11 @@ async function getInstance() {
     return rabbotInstance;
 }
 
+// Opitonal method to simplify initialization
+module.exports.initialize = async function initialize() {
+    await getInstance();
+};
+
 module.exports.subscribe = async function subscribe(queue, handler) {
     const r = await getInstance();
     console.info(`Listening to ${config.rabbitmq.host}:${config.rabbitmq.port} queue: ${queue}`);

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -45,6 +45,11 @@ async function getInstance() {
                                 debug(`connecting to instance host: ${config.rabbitmq.host}, port: ${config.rabbitmq.port}`);
                                 await rabbot.addConnection(connectionConfig);
                                 debug('rabbitmq connected');
+                                //Prior to this change, this is the original promise that failed. Publishing will always fail because of this.
+                                // https://github.com/arobson/rabbot/issues/108 @edorsey fix
+                                rabbot.connections[connectionConfig.name].promise = new Promise(function (resolve, reject) {
+                                    resolve()
+                                });
                             }
                             catch (e) {
                                 console.error('addConnection', e);

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -34,7 +34,7 @@ async function getInstance() {
                         {
                             times: 10,
                             interval: function (retryCount) {
-                                const wait = 20000 * Math.pow(2, retryCount);
+                                const wait = 10000 * Math.pow(2, retryCount);
                                 debug(`retry ${retryCount}, wait: ${wait} ms`);
 
                                 return wait;
@@ -89,6 +89,7 @@ async function getInstance() {
         }
         else {
             debug('waiting for valid rabbotInstance');
+            console.error(new Error('who'));
             await new Promise((resolve) => {
                 let checkIntervalId = setInterval(() => {
                     debug('checking for valid rabbotInstance');

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -21,7 +21,7 @@ async function getInstance() {
                         {
                             times: 10,
                             interval: function (retryCount) {
-                                const wait = 5000 * Math.pow(2, retryCount);
+                                const wait = 20000 * Math.pow(2, retryCount);
                                 debug(`retry ${retryCount}, wait: ${wait} ms`);
 
                                 return wait;

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -34,6 +34,10 @@ async function getInstance() {
                                     name: 'default',
                                     user: 'guest',
                                     pass: 'guest',
+                                    timeout: 10000,
+                                    replyTimeout: 5000,
+                                    failAfter: 30,
+                                    retryLimit: 30,
                                     host: config.rabbitmq.host,
                                     port: config.rabbitmq.port
                                 },

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -55,6 +55,8 @@ async function getInstance() {
                                     { exchange: exchange, target: constants.QUEUES.LOGGER, keys: [constants.QUEUES.LOGGER] }
                                 ]
                             });
+                            debug('rabbitmq configured');
+                            await rabbot.addConnection();
                             debug('rabbitmq connected');
                             console.dir(rabbot, { depth: 10 });
                             rabbotInstance = rabbot;

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -41,9 +41,15 @@ async function getInstance() {
                             }
                         },
                         async function connect() {
-                            debug(`connecting to instance host: ${config.rabbitmq.host}, port: ${config.rabbitmq.port}`);
-                            await rabbot.addConnection(connectionConfig);
-                            debug('rabbitmq connected');
+                            try {
+                                debug(`connecting to instance host: ${config.rabbitmq.host}, port: ${config.rabbitmq.port}`);
+                                await rabbot.addConnection(connectionConfig);
+                                debug('rabbitmq connected');
+                            }
+                            catch (e) {
+                                console.error('addConnection', e);
+                                throw e;
+                            }
                         }, (err) => {
                             if (err) {
                                 reject(new Error(err));

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -94,42 +94,54 @@ module.exports.initialize = async function initialize() {
 };
 
 module.exports.subscribe = async function subscribe(queue, handler) {
-    const r = await getInstance();
-    console.info(`Listening to ${config.rabbitmq.host}:${config.rabbitmq.port} queue: ${queue}`);
-    r.handle(queue, async (message) => {
-        debug(`queue: ${queue}, message: ${JSON.stringify(message)}`);
-        if (message && message.body) {
-            try {
-                const res = await handler(message.body);
-                if (res) {
-                    debug(`queue: ${queue}, ack`);
-                    message.ack();
+    try {
+        const r = await getInstance();
+        console.info(`Listening to ${config.rabbitmq.host}:${config.rabbitmq.port} queue: ${queue}`);
+        r.handle(queue, async (message) => {
+            debug(`queue: ${queue}, message: ${JSON.stringify(message)}`);
+            if (message && message.body) {
+                try {
+                    const res = await handler(message.body);
+                    if (res) {
+                        debug(`queue: ${queue}, ack`);
+                        message.ack();
+                    }
+                    else {
+                        debug(`queue: ${queue}, reject`);
+                        message.reject();
+                    }
                 }
-                else {
-                    debug(`queue: ${queue}, reject`);
+                catch (e) {
+                    console.error(e);
                     message.reject();
                 }
             }
-            catch (e) {
-                console.error(e);
-                message.reject();
+            else {
+                debug(`no message body queue: ${queue}, message: ${JSON.stringify(message)}`);
             }
-        }
-        else {
-            debug(`no message body queue: ${queue}, message: ${JSON.stringify(message)}`);
-        }
-    }, queue);
-    await r.startSubscription(queue);
+        }, queue);
+        await r.startSubscription(queue);
+    }
+    catch (e) {
+        console.error(`Unable to start subscription: ${queue}`, e);
+        throw new Error('Unable to subscribe');
+    }
 };
 
 module.exports.publish = async function publish(queue, message) {
-    const r = await getInstance();
+    try {
+        const r = await getInstance();
 
-    await r.publish(exchange, {
-        type: queue,
-        routingKey: queue,
-        body: message
-    });
+        await r.publish(exchange, {
+            type: queue,
+            routingKey: queue,
+            body: message
+        });
+    }
+    catch (e) {
+        console.error(`Unable to publish message to queue: ${queue}, message: ${message}`, e);
+        throw new Error('Unable to publish message');
+    }
 };
 
 process.on('beforeExit', async (code) => {

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -5,11 +5,24 @@ const config = require('./config');
 const constants = require('./constants');
 const debug = require('debug')('tilloo:rabbitfactory');
 const rabbot = require('rabbot');
+const { connect } = require('mongoose');
 
 let rabbotInstance = null;
 let initializing = false;
 
 const exchange = 'tilloo-x';
+
+const connectionConfig = {
+    name: 'default',
+    user: 'guest',
+    pass: 'guest',
+    timeout: 30000,
+    replyTimeout: 5000,
+    failAfter: 120,
+    retryLimit: 30,
+    host: config.rabbitmq.host,
+    port: config.rabbitmq.port
+};
 
 async function getInstance() {
     if (!rabbotInstance) {
@@ -27,39 +40,10 @@ async function getInstance() {
                                 return wait;
                             }
                         },
-                        async function initialize() {
-                            debug(`configuring instance host: ${config.rabbitmq.host}, port: ${config.rabbitmq.port}`);
-                            await rabbot.configure({
-                                connection: {
-                                    name: 'default',
-                                    user: 'guest',
-                                    pass: 'guest',
-                                    timeout: 30000,
-                                    replyTimeout: 5000,
-                                    failAfter: 120,
-                                    retryLimit: 30,
-                                    host: config.rabbitmq.host,
-                                    port: config.rabbitmq.port
-                                },
-                                exchanges: [
-                                    { name: exchange, type: 'direct' }
-                                ],
-                                queues: [
-                                    { name: constants.QUEUES.STATUS, limit: 25 },
-                                    { name: constants.QUEUES.SCHEDULER, limit: 25 },
-                                    { name: constants.QUEUES.LOGGER, limit: 25 }
-                                ],
-                                bindings: [
-                                    { exchange: exchange, target: constants.QUEUES.STATUS, keys: [constants.QUEUES.STATUS] },
-                                    { exchange: exchange, target: constants.QUEUES.SCHEDULER, keys: [constants.QUEUES.SCHEDULER] },
-                                    { exchange: exchange, target: constants.QUEUES.LOGGER, keys: [constants.QUEUES.LOGGER] }
-                                ]
-                            });
-                            debug('rabbitmq configured');
-                            await rabbot.addConnection();
+                        async function connect() {
+                            debug(`connecting to instance host: ${config.rabbitmq.host}, port: ${config.rabbitmq.port}`);
+                            await rabbot.addConnection(connectionConfig);
                             debug('rabbitmq connected');
-                            console.dir(rabbot, { depth: 10 });
-                            rabbotInstance = rabbot;
                         }, (err) => {
                             if (err) {
                                 reject(new Error(err));
@@ -69,6 +53,28 @@ async function getInstance() {
                             }
                         });
                 });
+
+                // Configure after the addConnection.  If the configure fails it doesn't properly
+                // return the promise.  If the addConnection() succeeds first rabbitMq is in a state
+                // to configure
+                await rabbot.configure({
+                    connection: connectionConfig,
+                    exchanges: [
+                        { name: exchange, type: 'direct' }
+                    ],
+                    queues: [
+                        { name: constants.QUEUES.STATUS, limit: 25 },
+                        { name: constants.QUEUES.SCHEDULER, limit: 25 },
+                        { name: constants.QUEUES.LOGGER, limit: 25 }
+                    ],
+                    bindings: [
+                        { exchange: exchange, target: constants.QUEUES.STATUS, keys: [constants.QUEUES.STATUS] },
+                        { exchange: exchange, target: constants.QUEUES.SCHEDULER, keys: [constants.QUEUES.SCHEDULER] },
+                        { exchange: exchange, target: constants.QUEUES.LOGGER, keys: [constants.QUEUES.LOGGER] }
+                    ]
+                });
+                debug('rabbitmq configured');
+                rabbotInstance = rabbot;
             }
             catch (e) {
                 console.error('Unable to connect to rabbitmq after multiple retries.  Terminating', e);

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -52,7 +52,7 @@ async function getInstance() {
                                 ]
                             });
                             debug('rabbitmq connected');
-                            console.dir(rabbot);
+                            console.dir(rabbot, { depth: 10 });
                             rabbotInstance = rabbot;
                         }, (err) => {
                             if (err) {
@@ -132,7 +132,7 @@ module.exports.subscribe = async function subscribe(queue, handler) {
 module.exports.publish = async function publish(queue, message) {
     try {
         const r = await getInstance();
-        console.dir(r);
+        console.dir(r, { depth: 10 });
         await r.publish(exchange, {
             type: queue,
             routingKey: queue,

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -19,11 +19,12 @@ async function getInstance() {
                 await new Promise((resolve, reject) => {
                     async.retry(
                         {
-                            times: 5,
+                            times: 10,
                             interval: function (retryCount) {
-                                debug(`retry ${retryCount}`);
+                                const wait = 5000 * Math.pow(2, retryCount);
+                                debug(`retry ${retryCount}, wait: ${wait} ms`);
 
-                                return 1000 * Math.pow(2, retryCount);
+                                return wait;
                             }
                         },
                         async function initialize() {
@@ -78,7 +79,7 @@ async function getInstance() {
                         checkIntervalId = undefined;
                         resolve();
                     }
-                }, 500);
+                }, 5000);
             });
 
         }

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -143,8 +143,8 @@ module.exports.subscribe = async function subscribe(queue, handler) {
 
 module.exports.publish = async function publish(queue, message) {
     try {
+        debug(`Publishing message to queue: ${queue}`);
         const r = await getInstance();
-        console.dir(r, { depth: 10 });
         await r.publish(exchange, {
             type: queue,
             routingKey: queue,

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -34,9 +34,9 @@ async function getInstance() {
                                     name: 'default',
                                     user: 'guest',
                                     pass: 'guest',
-                                    timeout: 10000,
+                                    timeout: 30000,
                                     replyTimeout: 5000,
-                                    failAfter: 30,
+                                    failAfter: 120,
                                     retryLimit: 30,
                                     host: config.rabbitmq.host,
                                     port: config.rabbitmq.port

--- a/lib/rabbitfactory.js
+++ b/lib/rabbitfactory.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const async = require('async');
 const config = require('./config');
 const constants = require('./constants');
 const debug = require('debug')('tilloo:rabbitfactory');
@@ -15,34 +16,54 @@ async function getInstance() {
         if (!initializing) {
             initializing = true;
             try {
-                debug(`configuring instance host: ${config.rabbitmq.host}, port: ${config.rabbitmq.port}`);
-                await rabbot.configure({
-                    connection: {
-                        name: 'default',
-                        user: 'guest',
-                        pass: 'guest',
-                        host: config.rabbitmq.host,
-                        port: config.rabbitmq.port
-                    },
-                    exchanges: [
-                        { name: exchange, type: 'direct' }
-                    ],
-                    queues: [
-                        { name: constants.QUEUES.STATUS, limit: 25 },
-                        { name: constants.QUEUES.SCHEDULER, limit: 25 },
-                        { name: constants.QUEUES.LOGGER, limit: 25 }
-                    ],
-                    bindings: [
-                        { exchange: exchange, target: constants.QUEUES.STATUS, keys: [constants.QUEUES.STATUS] },
-                        { exchange: exchange, target: constants.QUEUES.SCHEDULER, keys: [constants.QUEUES.SCHEDULER] },
-                        { exchange: exchange, target: constants.QUEUES.LOGGER, keys: [constants.QUEUES.LOGGER] }
-                    ]
+                await new Promise((resolve, reject) => {
+                    async.retry(
+                        {
+                            times: 5,
+                            interval: function (retryCount) {
+                                debug(`retry ${retryCount}`);
+
+                                return 1000 * Math.pow(2, retryCount);
+                            }
+                        },
+                        async function initialize() {
+                            debug(`configuring instance host: ${config.rabbitmq.host}, port: ${config.rabbitmq.port}`);
+                            await rabbot.configure({
+                                connection: {
+                                    name: 'default',
+                                    user: 'guest',
+                                    pass: 'guest',
+                                    host: config.rabbitmq.host,
+                                    port: config.rabbitmq.port
+                                },
+                                exchanges: [
+                                    { name: exchange, type: 'direct' }
+                                ],
+                                queues: [
+                                    { name: constants.QUEUES.STATUS, limit: 25 },
+                                    { name: constants.QUEUES.SCHEDULER, limit: 25 },
+                                    { name: constants.QUEUES.LOGGER, limit: 25 }
+                                ],
+                                bindings: [
+                                    { exchange: exchange, target: constants.QUEUES.STATUS, keys: [constants.QUEUES.STATUS] },
+                                    { exchange: exchange, target: constants.QUEUES.SCHEDULER, keys: [constants.QUEUES.SCHEDULER] },
+                                    { exchange: exchange, target: constants.QUEUES.LOGGER, keys: [constants.QUEUES.LOGGER] }
+                                ]
+                            });
+                            debug('rabbitmq connected');
+                            rabbotInstance = rabbot;
+                        }, (err) => {
+                            if (err) {
+                                reject(new Error(err));
+                            }
+                            else {
+                                resolve();
+                            }
+                        });
                 });
-                debug('rabbitmq connected');
-                rabbotInstance = rabbot;
             }
             catch (e) {
-                console.error('Unable to connect to rabbitmq.  Terminating', e);
+                console.error('Unable to connect to rabbitmq after multiple retries.  Terminating', e);
                 process.exit(1);
             }
         }


### PR DESCRIPTION
Currently the scheduler terminates if it can't connect to RabbitMQ on startup.

In a scenario where you are spinning up a whole stack RabbitMQ takes a minute or two to startup causing the scheduler to restart several times.

This adds retry logic to attempt to connect to RabbitMQ multiple times.