### PR TITLE
Add Human Readable Cron description under schedule

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,4 @@ LICENSE
 .gitignore
 docker-compose.yml
 Dockerfile
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ app/node_modules
 .vscode
 config.batch04
 config.json
+*.iml
 
 

--- a/web/client/package-lock.json
+++ b/web/client/package-lock.json
@@ -11,7 +11,7 @@
         "@mdi/font": "^7.2.96",
         "axios": "^1.4.0",
         "cron": "^2.3.0",
-        "cronstrue": "^2.27.0",
+        "cronstrue": "^2.50.0",
         "dayjs": "^1.11.7",
         "socket.io-client": "^4.6.1",
         "vue": "^2.7.14",
@@ -3713,9 +3713,9 @@
       }
     },
     "node_modules/cronstrue": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.27.0.tgz",
-      "integrity": "sha512-p+w818EttA27EfIeZP5Z3k3ps9hy6DlRv3txbWxysTIlWEAE6DdYIjCaaeZhWaNfcowuXZrg0HVFWLTqGb85hg==",
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.50.0.tgz",
+      "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==",
       "bin": {
         "cronstrue": "bin/cli.js"
       }
@@ -11578,9 +11578,9 @@
       }
     },
     "cronstrue": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.27.0.tgz",
-      "integrity": "sha512-p+w818EttA27EfIeZP5Z3k3ps9hy6DlRv3txbWxysTIlWEAE6DdYIjCaaeZhWaNfcowuXZrg0HVFWLTqGb85hg=="
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.50.0.tgz",
+      "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg=="
     },
     "crypto-browserify": {
       "version": "3.12.0",

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -12,7 +12,7 @@
     "@mdi/font": "^7.2.96",
     "axios": "^1.4.0",
     "cron": "^2.3.0",
-    "cronstrue": "^2.27.0",
+    "cronstrue": "^2.50.0",
     "dayjs": "^1.11.7",
     "socket.io-client": "^4.6.1",
     "vue": "^2.7.14",

--- a/web/client/src/views/AddEditJob.modal.vue
+++ b/web/client/src/views/AddEditJob.modal.vue
@@ -29,6 +29,7 @@
                   v-model="job.schedule"
                   label="Schedule"
                   :error-messages="scheduleErrors"
+                  :hint="scheduleDescription"
                 />
               </v-col>
               <v-col cols="5">
@@ -140,6 +141,7 @@ import jobService from "../services/job.service.js";
 import modalMixin from "../ModalMixin.js";
 import { validationMixin } from "vuelidate";
 import { required, integer, email } from "vuelidate/lib/validators";
+import cronstrue from "cronstrue";
 
 export default {
   mixins: [modalMixin, validationMixin],
@@ -180,6 +182,17 @@ export default {
   computed: {
     action() {
       return this.jobId ? "Update" : "Add";
+    },
+    scheduleDescription() {
+      if (this.job.schedule) {
+        try {
+          return cronstrue.toString(this.job.schedule);
+        } catch (e) {
+          return "Invalid schedule";
+        }
+      } else {
+        return undefined;
+      }
     },
     nameErrors() {
       const errors = [];


### PR DESCRIPTION
When creating a job or editing an existing one, add a human-readable description of the cron schedule as a hint underneath the Schedule form field.

Description is only visible when editing the form field. If the schedule is invalid, instead show 'Invalid Schedule'

update: .gitignore and .dockerignore to ignore .iml files
up: increase version of `cronstrue` package used in this feature.